### PR TITLE
Format with Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Summaries and metadata can be manually submitted (this will be automated later)
 The prototype is available at https://covid-science-engine-prototype.herokuapp.com/ (currently password protected)
 
 ## Developer setup
+
 The stack is:
 
 - Ruby on Rails 6.0
@@ -24,6 +25,7 @@ The stack is:
 ### Installation
 
 Install and start postgresql:
+
 - On macOS, you can use `pg_ctl -D /usr/local/var/postgres start`
 - (To stop postgres use `pg_ctl -D /usr/local/var/postgres stop`)
 
@@ -44,11 +46,10 @@ rails db:setup
 
 The following environment variables can be set:
 
-| Environment variable | Description |
-| ---------------------|--------------------------|
+| Environment variable | Description                       |
+| -------------------- | --------------------------------- |
 | `AUTH_USERNAME`      | Username for basic authentication |
 | `AUTH_PASSWORD`      | Password for basic authentication |
-
 
 ## Launch app
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The prototype is available at https://covid-science-engine-prototype.herokuapp.c
 The stack is:
 
 - Ruby on Rails 6.0
+- React (with TypeScript)
 - Tailwind CSS
 - Postgres
 - Heroku
@@ -42,6 +43,10 @@ Setup the database and seed data:
 rails db:setup
 ```
 
+### Editor
+
+You can use your editor of choice but please make sure to reformat your code with [Prettier](https://www.moeckernkiez.de/quartier-moeckernkiez/freie-wohnungen/kosten/) according to the `.prettierrc` file.
+
 ## Configuration
 
 The following environment variables can be set:
@@ -61,7 +66,7 @@ Then go to [http://localhost:3000](http://localhost:3000) to view the app.
 
 Currently, we have some basic authentication in front of the website. We will be replacing this with something better soon.
 
-In development, the username and password is `foo` /  `bar`.
+In development, the username and password is `foo` / `bar`.
 
 ## Running tests
 
@@ -70,6 +75,7 @@ rails spec
 ```
 
 # Contributing
+
 We are looking for new contributors to help us build this project.
 
 👉 Please read our [Contributing guide](CONTRIBUTING.md) to get started. 👈

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,4 +14,8 @@
  *= require_self
  */
 
- .field_with_errors {border-width: 2px; border-color: #f05252; flex: 1 1 0%;}
+.field_with_errors {
+  border-width: 2px;
+  border-color: #f05252;
+  flex: 1 1 0%;
+}

--- a/app/javascript/channels/consumer.js
+++ b/app/javascript/channels/consumer.js
@@ -1,6 +1,6 @@
 // Action Cable provides the framework to deal with WebSockets in Rails.
 // You can generate new channels where WebSocket features live using the `rails generate channel` command.
 
-import { createConsumer } from "@rails/actioncable"
+import { createConsumer } from '@rails/actioncable';
 
-export default createConsumer()
+export default createConsumer();

--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,5 +1,5 @@
 // Load all the channels within this directory and all subdirectories.
 // Channel files must be named *_channel.js.
 
-const channels = require.context('.', true, /_channel\.js$/)
-channels.keys().forEach(channels)
+const channels = require.context('.', true, /_channel\.js$/);
+channels.keys().forEach(channels);

--- a/app/javascript/css/application.css
+++ b/app/javascript/css/application.css
@@ -1,4 +1,4 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "./components.css";
-@import "tailwindcss/utilities";
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import './components.css';
+@import 'tailwindcss/utilities';

--- a/app/javascript/css/components.css
+++ b/app/javascript/css/components.css
@@ -1,73 +1,73 @@
 .big-title {
-    @apply text-2xl font-bold tracking-tight leading-tight;
+  @apply text-2xl font-bold tracking-tight leading-tight;
 }
 
 .big-subtitle {
-    @apply tracking-tight leading-tight mt-2;
+  @apply tracking-tight leading-tight mt-2;
 }
 
 @screen sm {
-    .big-title {
-        @apply text-4xl;
-    }
+  .big-title {
+    @apply text-4xl;
+  }
 
-    .big-subtitle {
-        @apply text-2xl;
-    }
+  .big-subtitle {
+    @apply text-2xl;
+  }
 }
 
 .small-title {
-    @apply text-lg leading-6 font-medium text-gray-900 ml-4 mt-4;
+  @apply text-lg leading-6 font-medium text-gray-900 ml-4 mt-4;
 }
 
 .card {
-    @apply shadow bg-white border border-gray-200 mb-6;
+  @apply shadow bg-white border border-gray-200 mb-6;
 }
 
 .card .card-inner {
-    @apply px-4 py-4;
+  @apply px-4 py-4;
 }
 
 @screen sm {
-    .card {
-        @apply rounded-md;
-    }
+  .card {
+    @apply rounded-md;
+  }
 
-    .card .card-inner {
-        @apply px-6;
-    }
+  .card .card-inner {
+    @apply px-6;
+  }
 }
 
 /* Card heading */
 .card h2 {
-    @apply text-xl leading-6 font-medium text-blue-600 truncate underline ml-0 mt-0;
+  @apply text-xl leading-6 font-medium text-blue-600 truncate underline ml-0 mt-0;
 }
 
 /* Card subheading */
 .card h3 {
-    @apply mt-1 leading-5 text-gray-600;
+  @apply mt-1 leading-5 text-gray-600;
 }
 
 .card .card-section {
-    @apply mt-4;
+  @apply mt-4;
 }
 
 h4 {
-    @apply font-medium text-sm text-blue-600 leading-4;
+  @apply font-medium text-sm text-blue-600 leading-4;
 }
 
 p {
-    @apply text-sm text-gray-700 mb-2 text-sm leading-5
+  @apply text-sm text-gray-700 mb-2 text-sm leading-5;
 }
 
 .button {
-    @apply px-4 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-blue-600 rounded-md shadow-sm
+  @apply px-4 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-white bg-blue-600 rounded-md shadow-sm;
 }
 
 .button:hover {
-    @apply bg-blue-500
+  @apply bg-blue-500;
 }
 
 .button:active {
-    @apply bg-blue-700
+  @apply bg-blue-700;
 }

--- a/app/javascript/css/tailwind.js
+++ b/app/javascript/css/tailwind.js
@@ -3,7 +3,5 @@ module.exports = {
     extend: {},
   },
   variants: {},
-  plugins: [
-    require('@tailwindcss/ui'),
-  ],
-}
+  plugins: [require('@tailwindcss/ui')],
+};

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,10 +3,10 @@
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
 
-require("@rails/ujs").start()
-require("turbolinks").start()
-require("@rails/activestorage").start()
-require("channels")
+require('@rails/ujs').start();
+require('turbolinks').start();
+require('@rails/activestorage').start();
+require('channels');
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
@@ -14,8 +14,8 @@ require("channels")
 //
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
-import '../css/application.css'
+import '../css/application.css';
 // Support component names relative to this directory:
-var componentRequireContext = require.context("components", true);
-var ReactRailsUJS = require("react_ujs");
+var componentRequireContext = require.context('components', true);
+var ReactRailsUJS = require('react_ujs');
 ReactRailsUJS.useContext(componentRequireContext);

--- a/app/javascript/packs/server_rendering.js
+++ b/app/javascript/packs/server_rendering.js
@@ -1,5 +1,5 @@
 // By default, this pack is loaded for server-side rendering.
 // It must expose react_ujs as `ReactRailsUJS` and prepare a require context.
-var componentRequireContext = require.context("components", true);
-var ReactRailsUJS = require("react_ujs");
+var componentRequireContext = require.context('components', true);
+var ReactRailsUJS = require('react_ujs');
 ReactRailsUJS.useContext(componentRequireContext);

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,9 +1,9 @@
-module.exports = function(api) {
-  var validEnv = ['development', 'test', 'production']
-  var currentEnv = api.env()
-  var isDevelopmentEnv = api.env('development')
-  var isProductionEnv = api.env('production')
-  var isTestEnv = api.env('test')
+module.exports = function (api) {
+  var validEnv = ['development', 'test', 'production'];
+  var currentEnv = api.env();
+  var isDevelopmentEnv = api.env('development');
+  var isProductionEnv = api.env('production');
+  var isTestEnv = api.env('test');
 
   if (!validEnv.includes(currentEnv)) {
     throw new Error(
@@ -11,8 +11,8 @@ module.exports = function(api) {
         '`BABEL_ENV` environment variables. Valid values are "development", ' +
         '"test", and "production". Instead, received: ' +
         JSON.stringify(currentEnv) +
-        '.'
-    )
+        '.',
+    );
   }
 
   return {
@@ -21,11 +21,11 @@ module.exports = function(api) {
         '@babel/preset-env',
         {
           targets: {
-            node: 'current'
+            node: 'current',
           },
-          modules: 'commonjs'
+          modules: 'commonjs',
         },
-        '@babel/preset-react'
+        '@babel/preset-react',
       ],
       (isProductionEnv || isDevelopmentEnv) && [
         '@babel/preset-env',
@@ -34,16 +34,16 @@ module.exports = function(api) {
           useBuiltIns: 'entry',
           corejs: 3,
           modules: false,
-          exclude: ['transform-typeof-symbol']
-        }
+          exclude: ['transform-typeof-symbol'],
+        },
       ],
       [
         '@babel/preset-react',
         {
           development: isDevelopmentEnv || isTestEnv,
-          useBuiltIns: true
-        }
-      ]
+          useBuiltIns: true,
+        },
+      ],
     ].filter(Boolean),
     plugins: [
       'babel-plugin-macros',
@@ -53,35 +53,35 @@ module.exports = function(api) {
       [
         '@babel/plugin-proposal-class-properties',
         {
-          loose: true
-        }
+          loose: true,
+        },
       ],
       [
         '@babel/plugin-proposal-object-rest-spread',
         {
-          useBuiltIns: true
-        }
+          useBuiltIns: true,
+        },
       ],
       [
         '@babel/plugin-transform-runtime',
         {
           helpers: false,
           regenerator: true,
-          corejs: false
-        }
+          corejs: false,
+        },
       ],
       [
         '@babel/plugin-transform-regenerator',
         {
-          async: false
-        }
+          async: false,
+        },
       ],
       isProductionEnv && [
         'babel-plugin-transform-react-remove-prop-types',
         {
-          removeImport: true
-        }
-      ]
-    ].filter(Boolean)
-  }
-}
+          removeImport: true,
+        },
+      ],
+    ].filter(Boolean),
+  };
+};

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,4 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  hello: 'Hello world'

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -1,5 +1,5 @@
-process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
-const environment = require('./environment')
+const environment = require('./environment');
 
-module.exports = environment.toWebpackConfig()
+module.exports = environment.toWebpackConfig();

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,5 +1,5 @@
-const { environment } = require('@rails/webpacker')
-const typescript =  require('./loaders/typescript')
+const { environment } = require('@rails/webpacker');
+const typescript = require('./loaders/typescript');
 
-environment.loaders.prepend('typescript', typescript)
-module.exports = environment
+environment.loaders.prepend('typescript', typescript);
+module.exports = environment;

--- a/config/webpack/loaders/typescript.js
+++ b/config/webpack/loaders/typescript.js
@@ -1,11 +1,11 @@
-const PnpWebpackPlugin = require('pnp-webpack-plugin')
+const PnpWebpackPlugin = require('pnp-webpack-plugin');
 
 module.exports = {
   test: /\.tsx?(\.erb)?$/,
   use: [
     {
       loader: 'ts-loader',
-      options: PnpWebpackPlugin.tsLoaderOptions()
-    }
-  ]
-}
+      options: PnpWebpackPlugin.tsLoaderOptions(),
+    },
+  ],
+};

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,5 +1,5 @@
-process.env.NODE_ENV = process.env.NODE_ENV || 'production'
+process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 
-const environment = require('./environment')
+const environment = require('./environment');
 
-module.exports = environment.toWebpackConfig()
+module.exports = environment.toWebpackConfig();

--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -1,5 +1,5 @@
-process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
-const environment = require('./environment')
+const environment = require('./environment');
 
-module.exports = environment.toWebpackConfig()
+module.exports = environment.toWebpackConfig();

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "version": "0.1.0",
   "devDependencies": {
+    "prettier": "2.0.5",
     "webpack-dev-server": "^3.10.3"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -4,11 +4,11 @@ module.exports = {
     require('postcss-flexbugs-fixes'),
     require('postcss-preset-env')({
       autoprefixer: {
-        flexbox: 'no-2009'
+        flexbox: 'no-2009',
       },
-      stage: 3
+      stage: 3,
     }),
     require('tailwindcss')('./app/javascript/css/tailwind.js'),
     require('autoprefixer'),
-  ]
-}
+  ],
+};

--- a/public/404.html
+++ b/public/404.html
@@ -1,67 +1,69 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>The page you were looking for doesn't exist (404)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+  <head>
+    <title>The page you were looking for doesn't exist (404)</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <style>
+      .rails-default-error-page {
+        background-color: #efefef;
+        color: #2e2f30;
+        text-align: center;
+        font-family: arial, sans-serif;
+        margin: 0;
+      }
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
+      .rails-default-error-page div.dialog {
+        width: 95%;
+        max-width: 33em;
+        margin: 4em auto 0;
+      }
 
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
+      .rails-default-error-page div.dialog > div {
+        border: 1px solid #ccc;
+        border-right-color: #999;
+        border-left-color: #999;
+        border-bottom-color: #bbb;
+        border-top: #b00100 solid 4px;
+        border-top-left-radius: 9px;
+        border-top-right-radius: 9px;
+        background-color: white;
+        padding: 7px 12% 0;
+        box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+      }
 
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
+      .rails-default-error-page h1 {
+        font-size: 100%;
+        color: #730e15;
+        line-height: 1.5em;
+      }
 
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
+      .rails-default-error-page div.dialog > p {
+        margin: 0 0 1em;
+        padding: 1em;
+        background-color: #f7f7f7;
+        border: 1px solid #ccc;
+        border-right-color: #999;
+        border-left-color: #999;
+        border-bottom-color: #999;
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+        border-top-color: #dadada;
+        color: #666;
+        box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+      }
+    </style>
+  </head>
 
-<body class="rails-default-error-page">
-  <!-- This file lives in public/404.html -->
-  <div class="dialog">
-    <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
+  <body class="rails-default-error-page">
+    <!-- This file lives in public/404.html -->
+    <div class="dialog">
+      <div>
+        <h1>The page you were looking for doesn't exist.</h1>
+        <p>You may have mistyped the address or the page may have moved.</p>
+      </div>
+      <p>
+        If you are the application owner check the logs for more information.
+      </p>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
+  </body>
 </html>

--- a/public/422.html
+++ b/public/422.html
@@ -1,67 +1,69 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>The change you wanted was rejected (422)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+  <head>
+    <title>The change you wanted was rejected (422)</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <style>
+      .rails-default-error-page {
+        background-color: #efefef;
+        color: #2e2f30;
+        text-align: center;
+        font-family: arial, sans-serif;
+        margin: 0;
+      }
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
+      .rails-default-error-page div.dialog {
+        width: 95%;
+        max-width: 33em;
+        margin: 4em auto 0;
+      }
 
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
+      .rails-default-error-page div.dialog > div {
+        border: 1px solid #ccc;
+        border-right-color: #999;
+        border-left-color: #999;
+        border-bottom-color: #bbb;
+        border-top: #b00100 solid 4px;
+        border-top-left-radius: 9px;
+        border-top-right-radius: 9px;
+        background-color: white;
+        padding: 7px 12% 0;
+        box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+      }
 
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
+      .rails-default-error-page h1 {
+        font-size: 100%;
+        color: #730e15;
+        line-height: 1.5em;
+      }
 
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
+      .rails-default-error-page div.dialog > p {
+        margin: 0 0 1em;
+        padding: 1em;
+        background-color: #f7f7f7;
+        border: 1px solid #ccc;
+        border-right-color: #999;
+        border-left-color: #999;
+        border-bottom-color: #999;
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+        border-top-color: #dadada;
+        color: #666;
+        box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+      }
+    </style>
+  </head>
 
-<body class="rails-default-error-page">
-  <!-- This file lives in public/422.html -->
-  <div class="dialog">
-    <div>
-      <h1>The change you wanted was rejected.</h1>
-      <p>Maybe you tried to change something you didn't have access to.</p>
+  <body class="rails-default-error-page">
+    <!-- This file lives in public/422.html -->
+    <div class="dialog">
+      <div>
+        <h1>The change you wanted was rejected.</h1>
+        <p>Maybe you tried to change something you didn't have access to.</p>
+      </div>
+      <p>
+        If you are the application owner check the logs for more information.
+      </p>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
+  </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -1,66 +1,68 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>We're sorry, but something went wrong (500)</title>
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  .rails-default-error-page {
-    background-color: #EFEFEF;
-    color: #2E2F30;
-    text-align: center;
-    font-family: arial, sans-serif;
-    margin: 0;
-  }
+  <head>
+    <title>We're sorry, but something went wrong (500)</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <style>
+      .rails-default-error-page {
+        background-color: #efefef;
+        color: #2e2f30;
+        text-align: center;
+        font-family: arial, sans-serif;
+        margin: 0;
+      }
 
-  .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
-    margin: 4em auto 0;
-  }
+      .rails-default-error-page div.dialog {
+        width: 95%;
+        max-width: 33em;
+        margin: 4em auto 0;
+      }
 
-  .rails-default-error-page div.dialog > div {
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #BBB;
-    border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
-    background-color: white;
-    padding: 7px 12% 0;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
+      .rails-default-error-page div.dialog > div {
+        border: 1px solid #ccc;
+        border-right-color: #999;
+        border-left-color: #999;
+        border-bottom-color: #bbb;
+        border-top: #b00100 solid 4px;
+        border-top-left-radius: 9px;
+        border-top-right-radius: 9px;
+        background-color: white;
+        padding: 7px 12% 0;
+        box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+      }
 
-  .rails-default-error-page h1 {
-    font-size: 100%;
-    color: #730E15;
-    line-height: 1.5em;
-  }
+      .rails-default-error-page h1 {
+        font-size: 100%;
+        color: #730e15;
+        line-height: 1.5em;
+      }
 
-  .rails-default-error-page div.dialog > p {
-    margin: 0 0 1em;
-    padding: 1em;
-    background-color: #F7F7F7;
-    border: 1px solid #CCC;
-    border-right-color: #999;
-    border-left-color: #999;
-    border-bottom-color: #999;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    border-top-color: #DADADA;
-    color: #666;
-    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
-  }
-  </style>
-</head>
+      .rails-default-error-page div.dialog > p {
+        margin: 0 0 1em;
+        padding: 1em;
+        background-color: #f7f7f7;
+        border: 1px solid #ccc;
+        border-right-color: #999;
+        border-left-color: #999;
+        border-bottom-color: #999;
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+        border-top-color: #dadada;
+        color: #666;
+        box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+      }
+    </style>
+  </head>
 
-<body class="rails-default-error-page">
-  <!-- This file lives in public/500.html -->
-  <div class="dialog">
-    <div>
-      <h1>We're sorry, but something went wrong.</h1>
+  <body class="rails-default-error-page">
+    <!-- This file lives in public/500.html -->
+    <div class="dialog">
+      <div>
+        <h1>We're sorry, but something went wrong.</h1>
+      </div>
+      <p>
+        If you are the application owner check the logs for more information.
+      </p>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
-  </div>
-</body>
+  </body>
 </html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6084,6 +6084,11 @@ prepend-http@^1.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
+prettier@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+
 pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"


### PR DESCRIPTION
Let's use [Prettier](https://prettier.io/) to format our HTML, CSS/Less and JS/TS files!

This PR sets up Prettier with a configuration file (`.prettierrc`) and reformats all files accordingly. Prettier also formats Markdown but I only reformatted the README.md for now to avoid unnecessary merge conflicts.

# Todos

- [x] Adjust `CONTRIBUTING.md` (as soon as it's in master, I suppose)